### PR TITLE
Allow configuring ingress type, protocol, and disabling the ingress

### DIFF
--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -8,15 +8,24 @@
         GITHUB_TOKEN: {{ @('github.oauth_token') }}
 {% endif %}
     labels:
+{% if @('app.ingress.type') is null %}
+      - traefik.enable=false
+{% else %}
       - traefik.backend={{ @('workspace.name') }}
       - traefik.frontend.rule=Host:{{ @('hostname') }}
       - traefik.docker.network=my127ws
       - traefik.port={{ @('app.port') }}
+{% if @('app.ingress.protocol') %}
+      - traefik.protocol={{ @('app.ingress.protocol') }}
+{% endif %}
+{% endif %}
     networks:
       private:
         aliases:
           - {{ @('hostname') }}
+{% if @('app.ingress.type') is not null %}
       shared: {}
+{% endif %}
     expose:
       - {{ @('app.port') }}
     environment:

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -6,6 +6,11 @@ attributes.default:
     port: 80
     health_port: 80
     services: []
+    ingress:
+      # possible ingress types are standard, istio, or ~ for none
+      # note istio requires a cluster that has istio configured as the ingress controller
+      type: standard
+      protocol: http
 
   domain: my127.site
   hostname: = @('namespace') ~ '.' ~ @('domain')

--- a/helm/app/templates/application/app/ingress.yaml
+++ b/helm/app/templates/application/app/ingress.yaml
@@ -1,9 +1,12 @@
-{{ if eq .Values.ingress "standard" }}
+{{ if eq .Values.ingress.type "standard" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   creationTimestamp: null
   labels:
+{{- if .Values.ingress.protocol }}  
+    ingress.kubernetes.io/protocol: {{ .Values.ingress.protocol }}
+{{- end }}
     app.service: {{ .Values.resourcePrefix }}app
   name: {{ .Values.resourcePrefix }}app
 spec:

--- a/helm/app/templates/application/app/istio-ingress.yaml
+++ b/helm/app/templates/application/app/istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.ingress "istio" }}
+{{ if eq .Values.ingress.type "istio" }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -11,5 +11,6 @@ service:
 
 port: {{ @('app.port') }}
 health_port: {{ @('app.health_port') }}
-ingress: "standard" # standard or istio
+ingress:
+{{ to_yaml(@('app.ingress'), 2, 2) | raw }}
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}


### PR DESCRIPTION
Not every service can serve plaintext http 1.1 (or h2c) but can do TLS alpn negotiation