### PR TITLE
HOTFIX: remove type from ingress templates

### DIFF
--- a/helm/app/templates/application/app/ingress.yaml
+++ b/helm/app/templates/application/app/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.ingress.type "standard" }}
+{{ if eq .Values.ingress "standard" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/helm/app/templates/application/app/istio-ingress.yaml
+++ b/helm/app/templates/application/app/istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.ingress.type "istio" }}
+{{ if eq .Values.ingress "istio" }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:


### PR DESCRIPTION
Removes `type` from ingress templates as this is not defined in the values implementation in Helm.