### PR TITLE
HOTFIX: define a standard ingress default

### DIFF
--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -22,6 +22,6 @@ resources:
 
 port: {{ @('app.port') }}
 health_port: {{ @('app.health_port') }}
-ingress:
-{{ to_yaml(@('app.ingress'), 2, 2) | raw }}
+
+ingress: "standard" # standard or istio
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}


### PR DESCRIPTION
* Should we be defining a default ingress for go services?