### PR TITLE
Replace prometheus annotations with operator podmonitor

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -6,6 +6,7 @@ attributes.default:
     health_port: 80
     services: []
     default_port:
+      name: http
       port: 80
     ingress:
       # possible ingress types are standard, istio, or ~ for none

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -30,11 +30,16 @@ attributes:
       istio:
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"
+      prometheus:
+        podMonitoring: false
       services:
         app:
           environment:
             APP_HOST: = @('pipeline.base.hostname')
             LOG_LEVEL: info
+          metricsEnabled: true
+          metricsEndpoints:
+            - port: = @('app.default_port.name')
     qa:
       enabled: no
       namespace: = @('workspace.name') 

--- a/helm/app/templates/_container-ports.tpl
+++ b/helm/app/templates/_container-ports.tpl
@@ -1,3 +1,4 @@
 {{- define "container.ports" }}
-  - containerPort: {{ .Values.default_port.port }}
+  - name: {{ .Values.default_port.name | quote }}
+    containerPort: {{ .Values.default_port.port }}
 {{- end }}

--- a/helm/app/templates/application/app/deployment.yaml
+++ b/helm/app/templates/application/app/deployment.yaml
@@ -13,9 +13,6 @@ spec:
     metadata:
       labels:
         app.service: {{ .Values.resourcePrefix }}app
-      annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: {{ quote .Values.default_port.port }}
     spec:
       containers:
       - env:

--- a/helm/app/templates/application/app/podmonitor.yaml
+++ b/helm/app/templates/application/app/podmonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.prometheus.podMonitoring -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.resourcePrefix }}webapp
+  labels:
+    app.service: {{ .Values.resourcePrefix }}webapp
+spec:
+  selector:
+    matchLabels:
+      app.service: {{ .Values.resourcePrefix }}webapp
+  podMetricsEndpoints:
+{{- if .Values.docker.services.app.metricsEnabled -}}
+{{ .Values.docker.services.app.metricsEndpoints | toYaml | nindent 6 -}}
+{{- end -}}
+{{- end -}}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -17,6 +17,9 @@ persistence:
   postgres:
 {{ to_yaml(@('persistence.postgres'), 2, 4) | raw }}
 
+prometheus:
+{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -18,7 +18,7 @@ persistence:
 {{ to_yaml(@('persistence.postgres'), 2, 4) | raw }}
 
 prometheus:
-{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+{{ to_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}


### PR DESCRIPTION
Name the container ports as referencing ports from their port integers are considered deprecated