### PR TITLE
Make versions for DB image attributes that can be easily overrided

### DIFF
--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -1,5 +1,5 @@
   mysql:
-    image: mysql:5.7
+    image: mysql:{{ @('services.mysql.version') }}
     labels:
       - traefik.enable=false
     environment:

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -1,5 +1,5 @@
   postgres:
-    image: postgres:9.6
+    image: postgres:{{ @('services.postgres.version') }}
     labels:
       - traefik.enable=false
     environment:

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -5,12 +5,14 @@ attributes:
         LOG_LEVEL: debug
         APP_HOST: = @('hostname')
     mysql:
+      version: 5.7
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_PASSWORD: = @('database.pass')
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
         MYSQL_USER: = @('database.user')
     postgres:
+      version: 9.6
       environment:
         POSTGRES_DB: = @('database.name')
         POSTGRES_PASSWORD: = @('database.pass')


### PR DESCRIPTION
Fixes #32 

I have kept the default values for the versions backwards-compatible for now, rather than changing them to latest. When we tag up 1.0.0 we can change these to be latest. 