### PR TITLE
Deduce the docker registry_url from repository

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -27,6 +27,7 @@ attributes.default:
     root_pass: DV6RdNY3QcFsBk7V
 
   docker:
+    registry_url: = get_docker_registry(@('docker.repository'))
     repository: = @("workspace.name")
     tagPrefix: = ''
     config: null

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -64,6 +64,15 @@ function('get_docker_external_networks'): |
   }
   = join(" ", $externalNetworks);
 
+function('get_docker_registry', [dockerRepository]): |
+  #!php
+  $dockerRepoParts = explode('/', $dockerRepository);
+  if (strpos($dockerRepoParts[0], '.') !== false) {
+      $registry = $dockerRepoParts[0];
+  }
+  = $registry ?? 'https://index.docker.io/v1/';
+
+
 function('go_mod_exists', [modulePath]): |
   #!php
   = file_exists($modulePath . '/go.mod');

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -4,9 +4,9 @@ command('build-prod'): |
 
 command('app publish'): |
   #!bash(workspace:/)|@
-  run docker login -u="@('docker.username')" -p="@('docker.password')" @('docker.repository')
+  run docker login -u="@('docker.username')" -p="@('docker.password')" @('docker.registry_url')
   run docker push @('docker.repository'):@('docker.tagPrefix')@('app.version')
-  run docker logout @('docker.repository')
+  run docker logout @('docker.registry_url')
 
 command('app deploy <environment>'):
   env:


### PR DESCRIPTION
Docker login doesn't work when the repository is using the default daemon registry (common when pushing to docker hub)

Also makes it clear there is no per-repository login credential store, only per-registry, so not good for parallel builds of different projects