### PR TITLE
Add ability to define env vars from k8s secrets

### DIFF
--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -28,5 +28,7 @@
 {% endif %}
     expose:
       - {{ @('app.default_port.port') }}
-    environment:
-{{ to_yaml(@('services.app.environment'), 2, 6) | raw }}
+    environment: {{ to_yaml(deep_merge([
+        @('services.app.environment'),
+        @('services.app.environment_secrets'),
+     ]), 2, 6) | raw }}

--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -28,7 +28,7 @@
 {% endif %}
     expose:
       - {{ @('app.default_port.port') }}
-    environment: {{ to_yaml(deep_merge([
+    environment: {{ to_nice_yaml(deep_merge([
         @('services.app.environment'),
         @('services.app.environment_secrets'),
      ]), 2, 6) | raw }}

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -2,8 +2,10 @@
     image: mysql:{{ @('services.mysql.version') }}
     labels:
       - traefik.enable=false
-    environment:
-{{ to_yaml(@('services.mysql.environment'), 2, 6) | raw }}
+    environment: {{ to_yaml(deep_merge([
+        @('services.mysql.environment'),
+        @('services.mysql.environment_secrets')
+      ]), 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -2,7 +2,7 @@
     image: mysql:{{ @('services.mysql.version') }}
     labels:
       - traefik.enable=false
-    environment: {{ to_yaml(deep_merge([
+    environment: {{ to_nice_yaml(deep_merge([
         @('services.mysql.environment'),
         @('services.mysql.environment_secrets')
       ]), 2, 6) | raw }}

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -2,7 +2,7 @@
     image: postgres:{{ @('services.postgres.version') }}
     labels:
       - traefik.enable=false
-    environment: {{ to_yaml(deep_merge([
+    environment: {{ to_nice_yaml(deep_merge([
         @('services.postgres.environment'),
         @('services.postgres.environment_secrets')
       ]), 2, 6) | raw }}

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -2,8 +2,10 @@
     image: postgres:{{ @('services.postgres.version') }}
     labels:
       - traefik.enable=false
-    environment:
-{{ to_yaml(@('services.postgres.environment'), 2, 6) | raw }}
+    environment: {{ to_yaml(deep_merge([
+        @('services.postgres.environment'),
+        @('services.postgres.environment_secrets')
+      ]), 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -8,16 +8,18 @@ attributes:
       version: 5.7
       environment:
         MYSQL_DATABASE: = @('database.name')
+        MYSQL_USER: = @('database.user')
+      environment_secrets:
         MYSQL_PASSWORD: = @('database.pass')
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
-        MYSQL_USER: = @('database.user')
     postgres:
       version: 9.6
       environment:
         POSTGRES_DB: = @('database.name')
-        POSTGRES_PASSWORD: = @('database.pass')
         POSTGRES_USER: = @('database.user')
         PGDATA: /var/lib/postgresql/data/pgdata
+      environment_secrets:
+        POSTGRES_PASSWORD: = @('database.pass')
 
   pipeline:
     publish:

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -1,5 +1,16 @@
 function('to_yaml', [data, indentation, nesting]): |
   #!php
+  if ($indentation || $nesting) {
+    trigger_error('to_yaml indentation and nesting is deprecated, use to_nice_yaml instead. to_yaml will in the future render to a single line', E_USER_DEPRECATED);
+  }
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, 2);
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), $yaml), "\n");
+  }
+  = $yaml;
+
+function('to_nice_yaml', [data, indentation, nesting]): |
+  #!php
   $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, 2);
   if (is_array($data) && count($data) > 0) {
     $yaml = "\n" . rtrim(preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), $yaml), "\n");

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -1,6 +1,39 @@
-function('to_yaml', [text, indentation, nesting]): |
+function('to_yaml', [data, indentation, nesting]): |
   #!php
-  = preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), \Symfony\Component\Yaml\Yaml::dump($text, 100, $indentation ?: 2));
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, 2);
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), $yaml), "\n");
+  }
+  = $yaml;
+
+function('deep_merge', [arrays]): |
+  #!php
+  // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
+  $deepMerge = function ($arrays) use (&$deepMerge) {
+    $result = array();
+    foreach ($arrays as $array) {
+        if ($array === null) { continue; }
+        foreach ($array as $key => $value) {
+            // Renumber integer keys as array_merge_recursive() does. Note that PHP
+            // automatically converts array keys that are integer strings (e.g., '1')
+            // to integers.
+            if (is_integer($key)) {
+                $result[] = $value;
+            }
+            elseif (isset($result[$key]) && is_array($result[$key]) && is_array($value)) {
+                $result[$key] = $deepMerge(array(
+                    $result[$key],
+                    $value,
+                ));
+            }
+            else {
+                $result[$key] = $value;
+            }
+        }
+    }
+    return $result;
+  };
+  = $deepMerge($arrays);
 
 function('docker_config', [attrConfig]): |
   #!php
@@ -20,6 +53,7 @@ function('branch'): |
 
 function('deep_merge_to_yaml', [arrays, indentation, nesting]): |
   #!php
+  trigger_error('deep_merge_to_yaml is deprecated, please use separate deep_merge and to_yaml functions', E_USER_DEPRECATED);
   // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
   $deepMerge = function ($arrays) use (&$deepMerge) {
     $result = array();
@@ -57,6 +91,24 @@ function('slugify', [text]): |
   $text = preg_replace('~-+~', '-', $text);
   $text = strtolower($text);
   = $text;
+
+function('filter_local_services', [services]): |
+  #!php
+  $filteredServices = [];
+  foreach ($services as $serviceName => $service) {
+    $filteredService = [];
+    foreach ($service as $key => $value) {
+      switch ($key) {
+        case 'environment':
+        case 'enabled':
+          $filteredService[$key] = $value;
+      }
+    }
+    if (count($filteredService) > 0) {
+      $filteredServices[$serviceName] = $filteredService;
+    }
+  }
+  = $filteredServices;
 
 function('get_docker_external_networks'): |
   #!php

--- a/harness/config/secrets.yml
+++ b/harness/config/secrets.yml
@@ -47,3 +47,50 @@ command('secret image-pull-config'):
       echo "If storing within workspace attributes, use `ws secret encrypt` first" >&2
       echo "${DOCKER_CONFIG}" | base64
     fi
+
+command('sealed-secret encrypt (string|blob) <secret-name>'):
+  env:
+    INPUT_TYPE: = input.command(3)
+    SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
+    SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
+    SECRET_NAME: = input.argument('secret-name')
+  exec: |
+    #!bash
+    if ! command -v kubeseal >/dev/null; then
+      echo 'kubeseal is needed in order to use this command' >&2
+      exit 1
+    fi
+    echo "Enter the secret ${INPUT_TYPE} to encrypt" >&2
+    case "${INPUT_TYPE}" in
+      string)
+        read DATA # read a single line
+        ;;
+      blob)
+        if [ -t 1 ] ; then
+          # Use an editor with a temp file to allow longer terminal input
+          TMPFILE="$(mktemp -t tmp.XXXXXXXXX)"
+          "${EDITOR:-vi}" "${TMPFILE}"
+          DATA="$(cat "${TMPFILE}")"
+          rm -f "${TMPFILE}"
+        else
+          # read from stdin until EOF
+          DATA="$(cat)"
+        fi
+        ;;
+    esac
+    echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+    KUBESEAL_OPTS=(
+      --name "${SECRET_NAME}"
+      --scope cluster-wide 
+    )
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-name "${SEALED_SECRETS_CONTROLLER_NAME}"
+      )
+    fi
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}"
+      )
+    fi
+    echo "${DATA}" | kubeseal --raw "${KUBESEAL_OPTS[@]}"

--- a/helm/app/templates/_secrets.tpl
+++ b/helm/app/templates/_secrets.tpl
@@ -1,0 +1,23 @@
+{{- define "service.environment.secret" }}
+{{ if .service.environment_secrets }}
+{{ if .Values.feature.sealed_secrets }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+{{ else }}
+apiVersion: v1
+kind: Secret
+{{ end }}
+metadata:
+  name: {{ .Values.resourcePrefix }}{{ .service_name }}
+{{ if .Values.feature.sealed_secrets }}
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
+spec:
+  encryptedData:
+{{ index .service.environment_secrets | toYaml | nindent 4 -}}
+{{ else }}
+stringData:
+{{ index .service.environment_secrets | toYaml | nindent 2 -}}
+{{ end }}
+{{ end }}
+{{- end }}

--- a/helm/app/templates/application/app/deployment.yaml
+++ b/helm/app/templates/application/app/deployment.yaml
@@ -22,6 +22,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.app.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}app
+        {{- end }}
         image: {{ .Values.docker.image.app }}
         imagePullPolicy: Always
         ports:

--- a/helm/app/templates/application/app/secret.yaml
+++ b/helm/app/templates/application/app/secret.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "app" "service" .Values.docker.services.app "Values" .Values) }}

--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -23,6 +23,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.mysql.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}mysql
+        {{- end }}
         image: mysql:5.7
         imagePullPolicy: Always
         args:

--- a/helm/app/templates/service/mysql/secret.yaml
+++ b/helm/app/templates/service/mysql/secret.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql "Values" .Values) }}

--- a/helm/app/templates/service/postgres/deployment.yaml
+++ b/helm/app/templates/service/postgres/deployment.yaml
@@ -23,6 +23,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.postgres.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}postgres
+        {{- end }}
         image: postgres:9.6
         imagePullPolicy: Always
         ports:

--- a/helm/app/templates/service/postgres/secret.yaml
+++ b/helm/app/templates/service/postgres/secret.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres "Values" .Values) }}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,10 +1,10 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
-feature: {{ to_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
-  services: {{ to_yaml(deep_merge([
+  services: {{ to_nice_yaml(deep_merge([
       filter_local_services(@('services')),
       @('pipeline.base.services')
     ]), 2, 4) | raw }}
@@ -16,17 +16,17 @@ service:
   mysql: {{ ("mysql" in @('app.services')) ? 'true' : 'false' }}
   postgres: {{ ("postgres" in @('app.services')) ? 'true' : 'false' }}
 
-persistence: {{ to_yaml(@('persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('persistence'), 2, 2) | raw }}
 
-prometheus: {{ to_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 
-default_port: {{ to_yaml(@('app.default_port'), 2, 2) | raw }}
+default_port: {{ to_nice_yaml(@('app.default_port'), 2, 2) | raw }}
 health_port: {{ @('app.health_port') }}
-ingress: {{ to_yaml(@('app.ingress'), 2, 2) | raw }}
-istio: {{ to_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
+ingress: {{ to_nice_yaml(@('app.ingress'), 2, 2) | raw }}
+istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
 
 {% include blocks ~ 'additional.yml.twig' %}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,12 +1,13 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
-feature:
-{{ to_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_yaml(@('helm.feature'), 2, 2) | raw }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
-  services:
-{{ deep_merge_to_yaml([@('services'), @('pipeline.base.services')], 2, 4) | raw }}
+  services: {{ to_yaml(deep_merge([
+      filter_local_services(@('services')),
+      @('pipeline.base.services')
+    ]), 2, 4) | raw }}
   image:
     app: {{ @('docker.repository') ~ ':' ~ @('docker.tagPrefix') ~ @('app.version') }}
 
@@ -15,25 +16,17 @@ service:
   mysql: {{ ("mysql" in @('app.services')) ? 'true' : 'false' }}
   postgres: {{ ("postgres" in @('app.services')) ? 'true' : 'false' }}
 
-persistence:
-  mysql:
-{{ to_yaml(@('persistence.mysql'), 2, 4) | raw }}
-  postgres:
-{{ to_yaml(@('persistence.postgres'), 2, 4) | raw }}
+persistence: {{ to_yaml(@('persistence'), 2, 2) | raw }}
 
-prometheus:
-{{ to_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 
-default_port:
-{{ to_yaml(@('app.default_port'), 2, 2) | raw }}
+default_port: {{ to_yaml(@('app.default_port'), 2, 2) | raw }}
 health_port: {{ @('app.health_port') }}
-ingress:
-{{ to_yaml(@('app.ingress'), 2, 2) | raw }}
-istio:
-{{ to_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
+ingress: {{ to_yaml(@('app.ingress'), 2, 2) | raw }}
+istio: {{ to_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
 
 {% include blocks ~ 'additional.yml.twig' %}

--- a/helm/qa/values.yaml.twig
+++ b/helm/qa/values.yaml.twig
@@ -1,5 +1,4 @@
 {{ @('workspace.name') }}:
   docker:
-    services:
-{{ to_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
+    services: {{ to_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
   resourcePrefix: {{ @('pipeline.qa.resourcePrefix') | json_encode | raw }}

--- a/helm/qa/values.yaml.twig
+++ b/helm/qa/values.yaml.twig
@@ -1,4 +1,4 @@
 {{ @('workspace.name') }}:
   docker:
-    services: {{ to_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
+    services: {{ to_nice_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
   resourcePrefix: {{ @('pipeline.qa.resourcePrefix') | json_encode | raw }}


### PR DESCRIPTION
* with sealed-secrets used by default for encryption
* support for custom CRD schemas necessary to pass tests
* local secrets (plaintext still) excluded from pipeline to avoid confusion over encryption
* Add better support for empty to*_yaml arrays and scalars
* Add a command to help with encrypting using sealed-secrets