### PR TITLE
Fix probe spec

### DIFF
--- a/helm/app/templates/_probes.tpl
+++ b/helm/app/templates/_probes.tpl
@@ -2,11 +2,11 @@
 readinessProbe:
   tcpSocket:
     port: {{ .Values.health_port }}
-    initialDelaySeconds: 5
-    periodSeconds: 10
+  initialDelaySeconds: 5
+  periodSeconds: 10
 livenessProbe:
   tcpSocket:
     port: {{ .Values.health_port }}
-    initialDelaySeconds: 10
-    periodSeconds: 10
+  initialDelaySeconds: 10
+  periodSeconds: 10
 {{- end }}


### PR DESCRIPTION
These fields would have been ignored where they were (or in some k8s clusters failing to release)