### PR TITLE
Add recompile command

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -74,3 +74,10 @@ command('go mod check'):
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper modules:check
+
+command('recompile'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)|@
+    passthru ws harness prepare && docker-compose up -d --build app


### PR DESCRIPTION
This is a faster alternative to `ws rebuild`, which destroys your whole stack and then rebuilds it. Instead, this command just does an in-place rebuild of the app container, essentially just recompiling your Go application, without touching the other running containers.

Closes #31.