### PR TITLE
Add gocyclo

### DIFF
--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -15,6 +15,7 @@ pipeline {
                 stage('go fmt') { steps { sh 'ws go fmt check' } }
                 stage('go test') { steps { sh 'ws go test' } }
                 stage('go vet') { steps { sh 'ws go vet' } }
+                stage('go gocyclo') { steps { sh 'ws go gocyclo' } }
                 stage('helm kubeval qa') { steps { sh 'ws helm kubeval qa' } }
             }
         }

--- a/docker/image/app/Dockerfile.twig
+++ b/docker/image/app/Dockerfile.twig
@@ -38,6 +38,8 @@ RUN go mod download
 
 RUN helper modules:after
 
+RUN go install github.com/fzipp/gocyclo/cmd/gocyclo
+
 COPY . .
 
 RUN go generate

--- a/docker/image/app/root/lib/task/gocyclo.sh.twig
+++ b/docker/image/app/root/lib/task/gocyclo.sh.twig
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function task_gocyclo()
+{
+    dirs="/app"
+    for d in /app/*/; do
+         dirs="${dirs} $d"
+    done
+
+    gocyclo -over {{ @('go.gocyclo.threshold') }} $dirs
+}

--- a/docker/image/app/root/lib/task/gocyclo.sh.twig
+++ b/docker/image/app/root/lib/task/gocyclo.sh.twig
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+shopt -s globstar
+
 function task_gocyclo()
 {
-    dirs="/app"
-    for d in /app/*/; do
+    dirs=""
+    for d in /app/**/*.go; do
          dirs="${dirs} $d"
     done
 
-    gocyclo -over {{ @('go.gocyclo.threshold') }} $dirs
+    gocyclo -over {{ @('go.gocyclo.threshold') }} "$dirs"
 }

--- a/docs/harness-attributes.md
+++ b/docs/harness-attributes.md
@@ -38,6 +38,8 @@ These attributes control how Go behaves in the built docker image. A full pictur
           steps: []
         before:
           steps: []
+      gocyclo:
+         threshold: 10
 
 #### `version`
 
@@ -67,6 +69,10 @@ Here you can set a bunch of arbitrary steps to execute before/after go modules h
 
 1. Run a full `ws install` and make sure you are happy with the result
 1. Commit your new shell script file, along with the `workspace.yml` change to define an overlay directory
+
+#### `gocyclo.threshold`
+
+This controls the cyclomatic complexity threshold for `gocyclo` checks in the Jenkins pipelines. If any function in your application exceeds this complexity threshold then the pipeline will fail. A lower setting is more strict, and a higher one is less so. See [`gocyclo`] for more information. Defaults to `10`.
 
 ### `app` attributes
 
@@ -136,3 +142,5 @@ This allows us to enable the bundling of certificates when the production image 
 #### `packages`
 
 This array attribute allows you to define an arbitrary number of `apt` packages to be installed when the Docker image is being built. Please note that these packages are only installed on the development image, and not the production image.
+
+[`gocyclo`]: https://github.com/fzipp/gocyclo

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -63,7 +63,9 @@ attributes.default:
         steps: []
       before:
         steps: []
-  
+    gocyclo:
+      threshold: 10
+
   helm:
     additional_schema_locations: https://inviqa.github.io/kubernetes-json-schema/schema
     feature:

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -61,6 +61,13 @@ command('go vet'):
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go vet ./...
 
+command('go gocyclo'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)|@
+    passthru docker-compose exec -T app helper gocyclo
+
 command('go fmt check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')

--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -5,6 +5,7 @@ confd('harness:/'):
   - { src: application/skeleton/.gitignore }
   - { src: docker/image/app/Dockerfile }
   - { src: docker/image/app/Dockerfile.prod }
+  - { src: docker/image/app/root/lib/task/gocyclo.sh }
   - { src: docker/image/app/root/lib/task/modules/after.sh }
   - { src: docker/image/app/root/lib/task/modules/before.sh }
   - { src: docker/image/app/root/lib/task/modules/check.sh }


### PR DESCRIPTION
Closes #65.

In the future, we should probably move all of the go tools to task shell scripts for consistency.