### PR TITLE
Only run the configured go.formatter on project Go files

### DIFF
--- a/application/skeleton/go.mod.twig
+++ b/application/skeleton/go.mod.twig
@@ -3,6 +3,6 @@ module {{ @('module_name') }}
 go {{ @('go.version') }}
 
 require (
-	github.com/sirupsen/logrus v1
 	github.com/prometheus/client_golang v1
+	github.com/sirupsen/logrus v1
 )

--- a/docker/image/app/root/lib/task/fmt/check.sh.twig
+++ b/docker/image/app/root/lib/task/fmt/check.sh.twig
@@ -2,5 +2,5 @@
 
 function task_fmt_check()
 {
-    {{ @('go.formatter') }} -l -w {{ @('app.src_path') }}
+    {{ @('go.formatter') }} -l -w "$(find . -type f -name '*.go' -not -path ".my127ws/*")"
 }


### PR DESCRIPTION
Sample project pipeline now passes using `goimports` as the configured `go.formatter`: https://jenkins.inviqa.com/blue/organizations/jenkins/inviqa-intapps%2Fharness-samples%2Fgo-sample/detail/PR-1/3/pipeline