### PR TITLE
Iterate over found Go files when executing formatter

### DIFF
--- a/docker/image/app/root/lib/task/fmt/check.sh.twig
+++ b/docker/image/app/root/lib/task/fmt/check.sh.twig
@@ -2,5 +2,8 @@
 
 function task_fmt_check()
 {
-    {{ @('go.formatter') }} -l -w "$(find . -type f -name '*.go' -not -path ".my127ws/*")"
+    find . -type f -name '*.go' -not -path "./.my127ws/*" | while IFS='' read -r line
+    do
+      {{ @('go.formatter') }} -l -w "$line"
+    done
 }


### PR DESCRIPTION
This is now working as expected, see sample project pipeline: https://jenkins.inviqa.com/blue/organizations/jenkins/inviqa-intapps%2Fharness-samples%2Fgo-sample/detail/PR-1/5/pipeline/28