### PR TITLE
Move module_name attribute -> go.module_name

### DIFF
--- a/.ci/sample-develop/workspace.yml
+++ b/.ci/sample-develop/workspace.yml
@@ -3,4 +3,4 @@ workspace('ci-go-sample'):
   harness: inviqa/go
 
 attribute('app.build'): develop
-attribute('module_name'): ci-go-sample
+attribute('go.module_name'): ci-go-sample

--- a/.ci/sample-production-with-certs/workspace.yml
+++ b/.ci/sample-production-with-certs/workspace.yml
@@ -3,5 +3,5 @@ workspace('ci-go-sample'):
   harness: inviqa/go
 
 attribute('app.build'): production
-attribute('module_name'): ci-go-sample
+attribute('go.module_name'): ci-go-sample
 attribute('app.bundle_certs'): yes

--- a/.ci/sample-production/workspace.yml
+++ b/.ci/sample-production/workspace.yml
@@ -3,4 +3,4 @@ workspace('ci-go-sample'):
   harness: inviqa/go
 
 attribute('app.build'): production
-attribute('module_name'): ci-go-sample
+attribute('go.module_name'): ci-go-sample

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,3 +6,4 @@ This document highlights breaking changes in releases that will require some mig
 
 * If you have a project template override for `Dockerfile.twig` to execute `go install` commands after modules are downloaded, you can now remove that in favour of defining steps in the `go.modules.after.steps` attribute.
 * The `image-dependencies.sh` file has been removed in favour of defining steps in the `go.modules.before.steps` attribute. 
+* The `module_name` attribute has been moved to `go.module_name`. You will need to change this attribute in your `workspace.yml` prior to updating to the 0.7.0 version of the harness.

--- a/application/skeleton/go.mod.twig
+++ b/application/skeleton/go.mod.twig
@@ -1,4 +1,4 @@
-module {{ @('module_name') }}
+module {{ @('go.module_name') }}
 
 go {{ @('go.version') }}
 

--- a/docs/development-and-production.md
+++ b/docs/development-and-production.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-When working locally, doing a `ws create-project ...` or `ws install`, a development image will be produced based on the upstream [`go` image]. This is based on [DebianBuster], which has a shell and system utilities available for use. We can install more packags when running this container using `apt` (see the [`app.packages` attribute])
+When working locally, doing a `ws create ...` or `ws install`, a development image will be produced based on the upstream [`go` image]. This is based on [DebianBuster], which has a shell and system utilities available for use. We can install more packags when running this container using `apt` (see the [`app.packages` attribute])
 
 This works really well when we are developing, as we will want to be able to install packages quickly to test various things.
 

--- a/docs/harness-attributes.md
+++ b/docs/harness-attributes.md
@@ -6,9 +6,9 @@ The Go harness has several attributes that you can use in your own project to co
 
 ## Required attributes
 
-Some attribute values are required in order to create a working application. You will be asked to provide these whenever you create a project (`ws create-project ...`):
+Some attribute values are required in order to create a working application. You will be asked to provide these whenever you create a project (`ws create ...`):
 
-* `module_name` - this will be the name of the Go module for your created application, e.g. `github.com/inviqa/repo-name`. This is stored in the generated `go.mod` file.
+* `go.module_name` - this will be the name of the Go module for your created application, e.g. `github.com/inviqa/repo-name`. This is stored in the generated `go.mod` file.
 
 ## Overriding attributes
 

--- a/harness.yml
+++ b/harness.yml
@@ -7,7 +7,7 @@ harness('inviqa/go'):
       - harness:/
     attributes:
       standard:
-        - module_name
+        - go.module_name
 ---
 import:
   - harness/config/*.yml


### PR DESCRIPTION
When I added this attribute back in https://github.com/inviqa/harness-go/commit/693266f1f5e3df1c16a7073f17d85ec61a9d09a1, I should have added it under `go`, this PR fixes this. If harnesses do not follow the upgrade doc and change their existing `module_name` attribute -> `go.module_name`, they will just get prompted for the new attribute value on `ws install`.

Passing pipeline with this change - https://github.com/inviqa/go-sample/pull/3