### PR TITLE
Add command to run unit tests with coverage

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -82,6 +82,11 @@ command('go mod check'):
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper modules:check
 
+command('go test coverage'):
+  exec: |
+    #!bash(workspace:/)|@
+    go test -coverprofile=cp.out ./... && go tool cover -html=cp.out
+
 command('recompile'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')


### PR DESCRIPTION
Adds a command which will run unit tests with a coverage check and outputs this to a report which is then viewable in a browser to highlight areas of code covered by tests.