### PR TITLE
Update go command naming convention

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,4 +7,4 @@ This document highlights breaking changes in releases that will require some mig
 * If you have a project template override for `Dockerfile.twig` to execute `go install` commands after modules are downloaded, you can now remove that in favour of defining steps in the `go.modules.after.steps` attribute.
 * The `image-dependencies.sh` file has been removed in favour of defining steps in the `go.modules.before.steps` attribute. 
 * The `module_name` attribute has been moved to `go.module_name`. You will need to change this attribute in your `workspace.yml` prior to updating to the 0.7.0 version of the harness.
-* The `go` commands have been updated to make it clear whether they run on the container or on the host machine. Commands ran on the container now follow the `ws go docker...` convention.
+* The `ws go` commands have been updated to make it clear whether they run on the container or on the host machine. Commands ran on the container now follow the `ws go docker...` convention.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,3 +7,4 @@ This document highlights breaking changes in releases that will require some mig
 * If you have a project template override for `Dockerfile.twig` to execute `go install` commands after modules are downloaded, you can now remove that in favour of defining steps in the `go.modules.after.steps` attribute.
 * The `image-dependencies.sh` file has been removed in favour of defining steps in the `go.modules.before.steps` attribute. 
 * The `module_name` attribute has been moved to `go.module_name`. You will need to change this attribute in your `workspace.yml` prior to updating to the 0.7.0 version of the harness.
+* The `go` commands have been updated to make it clear whether they run on the container or on the host machine. Commands ran on the container now follow the `ws go docker...` convention.

--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -11,12 +11,12 @@ pipeline {
         }
         stage('Test')  {
             parallel {
-                stage('go mod check') { steps { sh 'ws go mod check' } }
-                stage('go fmt') { steps { sh 'ws go fmt check' } }
-                stage('go test') { steps { sh 'ws go test' } }
-                stage('go vet') { steps { sh 'ws go vet' } }
-                stage('go gocyclo') { steps { sh 'ws go gocyclo' } }
-                stage('go ineffassign') { steps { sh 'ws go ineffassign' } }
+                stage('go mod check') { steps { sh 'ws go docker mod check' } }
+                stage('go fmt') { steps { sh 'ws go docker fmt check' } }
+                stage('go test') { steps { sh 'ws go docker test' } }
+                stage('go vet') { steps { sh 'ws go docker vet' } }
+                stage('go gocyclo') { steps { sh 'ws go docker gocyclo' } }
+                stage('go ineffassign') { steps { sh 'ws go docker ineffassign' } }
                 stage('helm kubeval qa') { steps { sh 'ws helm kubeval qa' } }
             }
         }

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -40,49 +40,49 @@ command('rebuild'): |
   $ws->run('destroy');
   $ws->run('install');
 
-command('go generate'):
+command('go docker generate'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go generate
 
-command('go test'):
+command('go docker test'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go test ./...
 
-command('go vet'):
+command('go docker vet'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go vet ./...
 
-command('go gocyclo'):
+command('go docker gocyclo'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper gocyclo
 
-command('go ineffassign'):
+command('go docker ineffassign'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper ineffassign
 
-command('go fmt check'):
+command('go docker fmt check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru test -z $(docker-compose exec -T app helper fmt:check)
 
-command('go mod check'):
+command('go docker mod check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |


### PR DESCRIPTION
Updates the naming convention used for the `go` workspace commands, to make it clear whether the command will run on the container or on the host.