### PR TITLE
Add "ws app" command for quick access to app container

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -44,6 +44,10 @@ command('app'): |
   #!bash(workspace:/)|@
   passthru docker-compose exec app bash
 
+command('console'): |
+  #!php
+  $ws->run('app');
+
 command('go docker generate'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -40,6 +40,10 @@ command('rebuild'): |
   $ws->run('destroy');
   $ws->run('install');
 
+command('app'): |
+  #!bash(workspace:/)|@
+  passthru docker-compose exec app bash
+
 command('go docker generate'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -44,6 +44,8 @@ command('app'): |
   #!bash(workspace:/)|@
   passthru docker-compose exec app bash
 
+# this is only here to make things easier for people who are familar with the other
+# harnesses, where `ws console` is used to quickly exec onto the main container
 command('console'): |
   #!php
   $ws->run('app');


### PR DESCRIPTION
This closes #82. It's akin to the `ws console` command on the PHP harnesses, but I've gone with `ws app` because:

1. It's placing the user in the `app` container, not `console` container
2. It's fewer keystrokes

However, I'm open to being swayed to `ws console` for consistency with other harnesses.