### PR TITLE
Output diff of go.mod/sum when mod check fails

### DIFF
--- a/docker/image/app/root/lib/task/modules/check.sh.twig
+++ b/docker/image/app/root/lib/task/modules/check.sh.twig
@@ -6,6 +6,7 @@ function task_modules_check()
 
     if git status --porcelain | grep "go\.mod"
     then
+      git diff go.mod go.sum
       echo "Run go mod tidy to fix your module dependencies."
       exit 1
     else

--- a/docker/image/app/root/lib/task/modules/check.sh.twig
+++ b/docker/image/app/root/lib/task/modules/check.sh.twig
@@ -3,14 +3,14 @@
 function task_modules_check()
 {
     go mod tidy -v
+    git diff --exit-code go.mod go.sum
 
-    if git status --porcelain | grep "go\.mod"
+    if [ $? -eq 0 ]
     then
-      git diff go.mod go.sum
-      echo "Run go mod tidy to fix your module dependencies."
-      exit 1
-    else
       echo "No unused or missing dependencies found in go.mod."
       exit 0
+    else
+      echo "Run go mod tidy to fix your module dependencies."
+      exit $?
     fi
 }


### PR DESCRIPTION
TODO:
- [x] consider bailing out if the `go.sum` has changed OR the `go.mod` instead of only `go.mod` 

Working example: https://github.com/inviqa/go-sample/pull/7/files