### PR TITLE
Install dev tools in modules:before step

### DIFF
--- a/docker/image/app/root/lib/task/modules/after.sh.twig
+++ b/docker/image/app/root/lib/task/modules/after.sh.twig
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-{% set version = @('go.version') > 1.15 ? '@latest' : '' %}
-
 function task_modules_after()
 {
-    {% for step in @('go.modules.after.steps') -%}
-        {{ step|raw }}
-    {% endfor %}
-
-    {% if @('go.formatter') == 'goimports' %}
-    go install golang.org/x/tools/cmd/goimports{{ version }}
+    {% if @('go.modules.after.steps') is empty %}
+        :
+    {% else %}
+        {% for step in @('go.modules.after.steps') -%}
+            {{ step|raw }}
+        {% endfor %}
     {% endif %}
-
-    go install github.com/fzipp/gocyclo/cmd/gocyclo{{ version }}
-    go install github.com/gordonklaus/ineffassign{{ version }}
 }

--- a/docker/image/app/root/lib/task/modules/before.sh.twig
+++ b/docker/image/app/root/lib/task/modules/before.sh.twig
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-{% set version = @('go.version') > 1.15 ? '@latest' : '' %}
+{% set operator = 'install' %}
+{% set version = '@latest' %}
+
+{% if @('go.version') < 1.16 %}
+    {% set operator = 'get' %}
+    {% set version = '' %}
+{% endif %}
 
 function task_modules_before()
 {
@@ -9,9 +15,9 @@ function task_modules_before()
     {% endfor %}
 
     {% if @('go.formatter') == 'goimports' %}
-    go install golang.org/x/tools/cmd/goimports{{ version }}
+    go {{ operator }} golang.org/x/tools/cmd/goimports{{ version }}
     {% endif %}
 
-    go install github.com/fzipp/gocyclo/cmd/gocyclo{{ version }}
-    go install github.com/gordonklaus/ineffassign{{ version }}
+    go {{ operator }} github.com/fzipp/gocyclo/cmd/gocyclo{{ version }}
+    go {{ operator }} github.com/gordonklaus/ineffassign{{ version }}
 }

--- a/docker/image/app/root/lib/task/modules/before.sh.twig
+++ b/docker/image/app/root/lib/task/modules/before.sh.twig
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+{% set version = @('go.version') > 1.15 ? '@latest' : '' %}
+
 function task_modules_before()
 {
-    {% if @('go.modules.before.steps') is empty %}
-        :
-    {% else %}
-        {% for step in @('go.modules.before.steps') -%}
-            {{ step|raw }}
-        {% endfor %}
+    {% for step in @('go.modules.before.steps') -%}
+        {{ step|raw }}
+    {% endfor %}
+
+    {% if @('go.formatter') == 'goimports' %}
+    go install golang.org/x/tools/cmd/goimports{{ version }}
     {% endif %}
+
+    go install github.com/fzipp/gocyclo/cmd/gocyclo{{ version }}
+    go install github.com/gordonklaus/ineffassign{{ version }}
 }


### PR DESCRIPTION
Currently, these tools are installed in the `modules:after` step, but this means that, whenever the project dependencies change,  they need to be redownloaded because the layer is invalidated in the docker build cache.

This moves the install to the `modules:before` step, meaning they should, generally, need to be re-downloaded far less frequently in the docker build.