### PR TITLE
Improve go mod init process

### DIFF
--- a/harness/scripts/mod_init.sh.twig
+++ b/harness/scripts/mod_init.sh.twig
@@ -2,9 +2,7 @@
 
 function mod_init() {
     go mod init {{ @('go.module_name') }}
-    go get github.com/prometheus/client_golang@v1
-    go get github.com/prometheus/client_golang/prometheus@v1
-    go get github.com/sirupsen/logrus@v1
+    go mod tidy
 }
 
 mod_init


### PR DESCRIPTION
Just running `go mod tidy` will pick up our dependencies from `main.go` in the skeleton and fetch dependencies all together, rather than the multiple `go get` calls we had previously which was far slower.