### PR TITLE
Lock go.version attribute on initial install

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -151,3 +151,32 @@ command('use prod'):
     passthru ws harness prepare
     passthru ws build-prod
     passthru && docker-compose up -d app
+
+# borrowed from https://github.com/inviqa/harness-base-php/blob/1.2.x/src/_base/harness/config/commands.yml#L179
+command('set <attribute> <value>'):
+  env:
+    ATTR_KEY: = input.argument('attribute')
+    ATTR_VAL: = input.argument('value')
+  exec: |
+    #!bash(workspace:/)|=
+    if [ ! -f workspace.yml ]; then
+      touch workspace.yml
+    fi
+    if grep -q "attribute('${ATTR_KEY}'):" workspace.yml; then
+      echo "Removing old '${ATTR_KEY}' setting from workspace.yml"
+      sed "/^attribute('${ATTR_KEY}'): .*$/d" workspace.yml > workspace.yml.tmp && mv workspace.yml.tmp workspace.yml
+    fi
+    if grep -q "attribute('${ATTR_KEY}'):" workspace.yml; then
+      echo 'Could not remove line from workspace.yml, failing'
+      exit 1
+    fi
+    echo "Setting '${ATTR_KEY}' setting to '${ATTR_VAL}' in workspace.yml"
+    echo "" >> workspace.yml
+    echo "attribute('${ATTR_KEY}'): ${ATTR_VAL}" >> workspace.yml
+
+command('get <attribute>'):
+  env:
+    VALUE: = @(input.argument('attribute'))
+  exec: |
+    #!bash(workspace:/)|@
+    echo "$VALUE"

--- a/harness/scripts/init.sh.twig
+++ b/harness/scripts/init.sh.twig
@@ -3,6 +3,7 @@
 function init() {
     if [ ! -f "go.mod" ]; then
       docker run --rm -v "$(pwd):/app" -w /app golang:{{ @('go.version') }} bash ./.my127ws/harness/scripts/mod_init.sh
+      ws set go.version {{ @('go.version') }}
     fi
 }
 

--- a/test
+++ b/test
@@ -28,6 +28,13 @@ function test()
 
     ws install
 
+    local lockedversion
+    lockedversion=$(ws get go.version)
+    if [ "$lockedversion" != "$goversion" ]; then
+      echo "Expected a locked go.version value of $goversion, but got $lockedversion."
+      exit 1
+    fi
+
     ws helm kubeval qa
 
     ws disable


### PR DESCRIPTION
Closes #111.

This adds the `ws set|get` commands, and calls the set on the first install, when creating the project, to lock `go.version`. 