### PR TITLE
Pass environment variables to all host integration test commands

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -124,7 +124,7 @@ command('go test integration <test-name>'):
     TEST_NAME: = input.argument('test-name')
   exec: |
     #!bash(workspace:/)|@
-    LOG_LEVEL=debug go test -count=1 -v --tags=integration ./integration/ -run ${TEST_NAME}
+    source .my127ws/harness/scripts/integration/run-one.sh ${TEST_NAME}
 
 command('go test integration'):
   exec: |

--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -14,6 +14,7 @@ confd('harness:/'):
   - { src: harness/scripts/mod_init.sh }
   - { src: harness/scripts/init.sh }
   - { src: harness/scripts/integration/run.sh }
+  - { src: harness/scripts/integration/run-one.sh }
   - { src: helm/app/Chart.yaml }
   - { src: helm/app/values.yaml }
   - { src: helm/qa/Chart.yaml }

--- a/harness/scripts/integration/run-one.sh.twig
+++ b/harness/scripts/integration/run-one.sh.twig
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 integration_run_one() {
-    env {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=debug go test -count=1 -v --tags=integration ./integration/ -run "$1"
+    env -- {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=debug go test -count=1 -v --tags=integration ./integration/ -run "$1"
 }
 
 integration_run_one "$1"

--- a/harness/scripts/integration/run-one.sh.twig
+++ b/harness/scripts/integration/run-one.sh.twig
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+integration_run_one() {
+    env {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=debug go test -count=1 -v --tags=integration ./integration/ -run "$1"
+}
+
+integration_run_one "$1"

--- a/harness/scripts/integration/run.sh.twig
+++ b/harness/scripts/integration/run.sh.twig
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 integration_run() {
-    env {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/
+    env -- {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/
 }
 
 integration_run

--- a/harness/scripts/integration/run.sh.twig
+++ b/harness/scripts/integration/run.sh.twig
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 integration_run() {
-    {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/
+    env {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/
 }
 
 integration_run


### PR DESCRIPTION
Also fix the escaping of shell args in the integration test scripts.