### PR TITLE
Fix volume mount name key

### DIFF
--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -47,11 +47,11 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         volumeMounts:
-        - {{ $.Values.resourcePrefix }}name: mysql-persistent-storage
+        - name: mysql-persistent-storage
           mountPath: /var/lib/mysql
       restartPolicy: Always
       volumes:
-      - {{ $.Values.resourcePrefix }}name: mysql-persistent-storage
+      - name: mysql-persistent-storage
 {{- if $.Values.persistence.mysql.enabled }}
         persistentVolumeClaim:
           claimName: {{ $.Values.resourcePrefix }}mysql-pv-claim


### PR DESCRIPTION
Volume `name:` key was incorrectly prefixed with the service name