### PR TITLE
Fix missing imagePullSecrets in jobs and cronjobs

### DIFF
--- a/helm/app/templates/application/cronjobs.yaml
+++ b/helm/app/templates/application/cronjobs.yaml
@@ -77,9 +77,9 @@ spec:
                 {{- end }}
               {{- end }}
           enableServiceLinks: false
-{{- if .Values.docker.image_pull_config }}
+{{- if $.Values.docker.image_pull_config }}
           imagePullSecrets:
-          - name: {{ .Values.resourcePrefix }}image-pull-config
+          - name: {{ $.Values.resourcePrefix }}image-pull-config
 {{- end }}
           {{- if $service.serviceAccountName }}
           serviceAccountName: {{ tpl $service.serviceAccountName $ | quote }}

--- a/helm/app/templates/application/jobs.yaml
+++ b/helm/app/templates/application/jobs.yaml
@@ -70,9 +70,9 @@ spec:
             {{- end }}
           {{- end }}
       enableServiceLinks: false
-{{- if .Values.docker.image_pull_config }}
+{{- if $.Values.docker.image_pull_config }}
       imagePullSecrets:
-      - name: {{ .Values.resourcePrefix }}image-pull-config
+      - name: {{ $.Values.resourcePrefix }}image-pull-config
 {{- end }}
       restartPolicy: Never
       {{- if $service.serviceAccountName }}


### PR DESCRIPTION
Due to using range, "." is changed, so $ is needed