### PR TITLE
Cleanup built docker images in Jenkins

### DIFF
--- a/docker/image/app/Dockerfile.prod.twig
+++ b/docker/image/app/Dockerfile.prod.twig
@@ -1,4 +1,5 @@
 FROM {{ @('docker.repository')}}:{{ @('docker.tagPrefix') }}{{ @('app.version') }} AS source
+LABEL build="{{ @('namespace') ~ ':' ~ @('app.version') }}"
 
 FROM scratch
 

--- a/docker/image/app/Dockerfile.twig
+++ b/docker/image/app/Dockerfile.twig
@@ -1,4 +1,5 @@
 FROM golang:{{ @('go.version')}} AS golang
+LABEL build="{{ @('namespace') ~ ':' ~ @('app.version') }}"
 
 {% for envName, envValue in @('go.environment')|filter(v => v is not empty) %}
 ENV {{ envName }}={{ envValue }}

--- a/harness/config/cleanup.yml
+++ b/harness/config/cleanup.yml
@@ -1,0 +1,24 @@
+function('built_images', [services]): |
+  #!php
+  $builtImages = [];
+  foreach ($services as $service) {
+    if ($service['image'] && count($service['upstream']) > 0) {
+      $builtImages[] = $service['image'];
+    }
+  }
+  $allImages = explode("\n", shell_exec('docker image ls -a --format \'{{ print .Repository ":" .Tag }}\''));
+  # workspace commands don't allow non-string types
+  = join(' ', array_intersect($builtImages, $allImages));
+
+command('cleanup built-images'):
+  env:
+    BUILD_LABEL: = @('namespace') ~ ':' ~ @('app.version')
+    IMAGES: = built_images(docker_service_images())
+  exec: |
+    #!bash
+    IMAGES=($IMAGES)
+    if [ "${#IMAGES[@]}" -gt 0 ]; then
+      run docker image rm --force -- "${IMAGES[@]}"
+    fi
+    run docker image prune --force --filter=label=build="$BUILD_LABEL"
+    [ -z "$(docker builder 2>&1)" ] || run docker builder prune --force --filter=label=build="$BUILD_LABEL"

--- a/harness/scripts/destroy.sh
+++ b/harness/scripts/destroy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 run docker-compose down --rmi local --volumes --remove-orphans
+passthru ws cleanup built-images
 run rm -f .my127ws/.flag-built


### PR DESCRIPTION
Port of https://github.com/inviqa/harness-base-php/pull/534 and https://github.com/inviqa/harness-base-php/pull/550

We noticed that a 2.5GB docker image was being left behind on the Jenkins worker nodes that doesn't get cleaned up.

If the pipeline makes it that far, the "build-prod" step replaces the docker image tag with a ~10MB image but the old 2.5GB development version will be stick around until pruned.