### PR TITLE
Add support for external image registries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,4 +13,5 @@ This is the documentation for the Go harness.
     * [How to add benchmarks to your app](how-to-guides/add-benchmarks.md)
     * [How to add Kafka (and Zookeeper)](how-to-guides/add-kafka.md)
     * [How to test a production image build locally](how-to-guides/test-production-image-build-locally.md)
+    * [How to use private external images](how-to-guides/use-private-external-images.md)
     * [How to write integration tests](how-to-guides/write-integration-tests.md)

--- a/docs/how-to-guides/use-private-external-images.md
+++ b/docs/how-to-guides/use-private-external-images.md
@@ -21,8 +21,8 @@ You will need a username and password for a robot/machine user in your desired r
       image: quay.io/my_images/foo:latest
       environment:
         FOO: "bar"
-    networks:
-      private: {}
+      networks:
+        private: {}
    ```
 4. Add your  to the `app.services` attribute:
    ```

--- a/docs/how-to-guides/use-private-external-images.md
+++ b/docs/how-to-guides/use-private-external-images.md
@@ -24,7 +24,7 @@ You will need a username and password for a robot/machine user in your desired r
       networks:
         private: {}
    ```
-4. Add your  to the `app.services` attribute:
+3. Add your  to the `app.services` attribute:
    ```
    attributes:
      app:

--- a/docs/how-to-guides/use-private-external-images.md
+++ b/docs/how-to-guides/use-private-external-images.md
@@ -1,0 +1,48 @@
+# How to use private external docker images
+
+Sometimes you may need to pull in a docker image that is not in a public registry. You may also need to pull in several docker images from different registries. This guide explains how to do that.
+
+## Prerequisites
+
+You will need a username and password for a robot/machine user in your desired registries. This should be a user that is used solely for the purposes of your application or project for pulling docker images from that registry.
+
+## Configuring external image registries
+
+1. Ensure that your `workspace.yml` has an overlay directory defined:
+   ```yaml
+   workspace('my-app'):
+    harness: inviqa/go:v0.10
+    overlay: tools/workspace
+   ```
+2. Create your `docker-compose.yml` configuration for your service that uses the private docker image:
+   `tools/workspace/_twig/docker-compose.yml/service/my-service.yml.twig`:
+   ```yaml
+     my-service:
+      image: quay.io/my_images/foo:latest
+      environment:
+        FOO: "bar"
+    networks:
+      private: {}
+   ```
+4. Add your  to the `app.services` attribute:
+   ```
+   attributes:
+     app:
+       services: [my-service]
+   ```
+
+Now, you need to update the `docker.external_image_registries` attribute with each of the registries that your private images use. For example, our `my-service` service above comes from `quay.io`, so we need to add that registry as follows:
+
+`workspace.yml`:
+```yaml
+attributes:
+  docker:
+    external_image_registries:
+      - url: quay.io
+        username: my-user
+        password: = decrypt('foo')
+```
+
+>_NOTE: The password values should be run through `ws secret encrypt` on the CLI, with the encrypted value being added to the `decrypt()` function call in place of foo/bar in the example above._
+
+Now, you can run `ws install` or `ws rebuild` and it will pull your external image.

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -41,6 +41,8 @@ attributes.default:
       url: = get_docker_registry(@('docker.repository'))
       username: = @('docker.username') # for backwards compatibility
       password: = @('docker.password') # for backwards compatibility
+    # each should have properties url, password and username
+    external_image_registries: []
     repository: = @("workspace.name")
     tagPrefix: = ''
 

--- a/harness/config/external-images.yml
+++ b/harness/config/external-images.yml
@@ -38,25 +38,25 @@ command('external-images config [--skip-exists]'):
 
 command('external-images pull'):
   env:
-    EXTERNAL_REGISTRIES: json_encode(@('docker.external_image_registries'))
+    EXTERNAL_REGISTRIES: = json_encode(@('docker.external_image_registries'))
   exec: |
     #!php
     foreach (json_decode($env['EXTERNAL_REGISTRIES'], true) as $registry) {
       $pass = escapeshellarg($registry['password']);
       $user = escapeshellarg($registry['username']);
       $url = escapeshellarg($registry['url']);
-      shell_exec("echo $pass | run docker login --username=$user --password-stdin $url");
+      shell_exec("echo $pass | docker login --username=$user --password-stdin $url");
     }
 
     $confArgs = [];
-    if (strlen(@$env['CI']) > 0 || strlen(@$env['BUILD_ID']) {
+    if (strlen(@$env['CI']) > 0 || strlen(@$env['BUILD_ID']) > 0) {
       $confArgs[] = "--skip-exists";
     }
     $confArgs = escapeshellarg(join(' ', $confArgs));
 
-    shell_exec("passthru \"ws external-images config $confArgs | docker-compose -f - pull\"");
+    shell_exec("ws external-images config $confArgs | docker-compose -f - pull");
 
     foreach (json_decode($env['EXTERNAL_REGISTRIES'], true) as $registry) {
       $url = escapeshellarg($registry['url']);
-      shell_exec("run docker logout $url");
+      shell_exec("docker logout $url");
     }

--- a/harness/config/external-images.yml
+++ b/harness/config/external-images.yml
@@ -45,7 +45,9 @@ command('external-images pull'):
       $pass = escapeshellarg($registry['password']);
       $user = escapeshellarg($registry['username']);
       $url = escapeshellarg($registry['url']);
-      shell_exec("echo $pass | docker login --username=$user --password-stdin $url");
+      $command = "docker login --username=$user --password-stdin $url";
+      echo $command . PHP_EOL;
+      passthru("echo $pass | $command");
     }
 
     $confArgs = [];
@@ -54,9 +56,13 @@ command('external-images pull'):
     }
     $confArgs = escapeshellarg(join(' ', $confArgs));
 
-    shell_exec("ws external-images config $confArgs | docker-compose -f - pull");
+    $command = "ws external-images config $confArgs | docker-compose -f - pull";
+    echo $command . PHP_EOL;
+    passthru($command);
 
     foreach (json_decode($env['EXTERNAL_REGISTRIES'], true) as $registry) {
       $url = escapeshellarg($registry['url']);
-      shell_exec("docker logout $url");
+      $command = "docker logout $url";
+      echo $command . PHP_EOL;
+      passthru($command);
     }

--- a/harness/config/external-images.yml
+++ b/harness/config/external-images.yml
@@ -54,7 +54,7 @@ command('external-images pull'):
     if (strlen(@$env['CI']) > 0 || strlen(@$env['BUILD_ID']) > 0) {
       $confArgs[] = "--skip-exists";
     }
-    $confArgs = escapeshellarg(join(' ', $confArgs));
+    $confArgs = join(' ', array_map('escapeshellarg', $confArgs));
 
     $command = "ws external-images config $confArgs | docker-compose -f - pull";
     echo $command . PHP_EOL;

--- a/harness/config/external-images.yml
+++ b/harness/config/external-images.yml
@@ -36,11 +36,27 @@ command('external-images config [--skip-exists]'):
     }
     echo \Symfony\Component\Yaml\Yaml::dump($compose, 100, 2);
 
-command('external-images pull'): |
-  #!bash(workspace:/)|@
-  CONF_ARGS=()
-  if [ -n "${CI:-}" ] || [ -n "${BUILD_ID:-}" ]; then
-    CONF_ARGS+=(--skip-exists)
-  fi
+command('external-images pull'):
+  env:
+    EXTERNAL_REGISTRIES: json_encode(@('docker.external_image_registries'))
+  exec: |
+    #!php
+    foreach (json_decode($env['EXTERNAL_REGISTRIES'], true) as $registry) {
+      $pass = escapeshellarg($registry['password']);
+      $user = escapeshellarg($registry['username']);
+      $url = escapeshellarg($registry['url']);
+      shell_exec("echo $pass | run docker login --username=$user --password-stdin $url");
+    }
 
-  passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"
+    $confArgs = [];
+    if (strlen(@$env['CI']) > 0 || strlen(@$env['BUILD_ID']) {
+      $confArgs[] = "--skip-exists";
+    }
+    $confArgs = escapeshellarg(join(' ', $confArgs));
+
+    shell_exec("passthru \"ws external-images config $confArgs | docker-compose -f - pull\"");
+
+    foreach (json_decode($env['EXTERNAL_REGISTRIES'], true) as $registry) {
+      $url = escapeshellarg($registry['url']);
+      shell_exec("run docker logout $url");
+    }

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -193,3 +193,7 @@ function('go_mod_exists', [modulePath]): |
 function('escapeshellarg', [value]): |
   #!php
   = escapeshellarg($value);
+
+function('json_encode', [value]): |
+  #!php
+  = json_encode($value);


### PR DESCRIPTION
External image registries can be defined like this:

```yaml
docker:
    external_image_registries:
      - url: quay.io
        username: foo
        password: = decrypt('...')
```

TODO:
- [x] get feedback
- [x] update documentation and write how-to guide