### PR TITLE
Use recreate stategy for MySQL Deployment

### DIFF
--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ $.Values.resourcePrefix }}mysql
+{{- if $.Values.persistence.mysql.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
When backed by a persistent volume, the volume can only be attached to one node at a time.
When updating the spec of the deployment object, the new pod is unable to start until the old one is manually deleted.

Imports https://github.com/inviqa/harness-base-php/pull/385