### PR TITLE
Switch Kafka and Zookeeper images to bitnami variants

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,10 @@
 # Upgrades
 
-This document highlights breaking changes in releases that will require some migration effort in your project. As we move towards a `1.0.0` release these will be restricted to major upgrades only, but currently, whilst the API is still being fleshed out in the `0.x` releases, they may be more frequent. 
+This document highlights breaking changes in releases that will require some migration effort in your project. As we move towards a `1.0.0` release these will be restricted to major upgrades only, but currently, whilst the API is still being fleshed out in the `0.x` releases, they may be more frequent.
+
+## `0.12.x` -> `0.13.0`
+
+* The default Kafka and Zookeeper images have been switched to [bitnami/kafka](https://hub.docker.com/r/bitnami/kafka) and [bitnami/zookeeper](https://hub.docker.com/r/bitnami/zookeeper), respectively. If you want to continue using the legacy wurstmeister images, you will need to specify this in your `kafka.image` and `zookeeper.image` attributes.  
 
 ## `0.9.x` -> `0.10.0`
 

--- a/_twig/docker-compose.yml/service/kafka.yml.twig
+++ b/_twig/docker-compose.yml/service/kafka.yml.twig
@@ -1,27 +1,22 @@
   kafka:
-    image: wurstmeister/kafka:{{ @('kafka.version') }}
+    image: {{ @('kafka.image') }}:{{ @('kafka.version') }}
     ports:
     - 9092
     environment:
-      KAFKA_LISTENERS: LISTENER_INT://kafka:29092,LISTENER_EXT://kafka:9092
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_INT://kafka:29092,LISTENER_EXT://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_INT:PLAINTEXT,LISTENER_EXT:PLAINTEXT
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: LISTENER_INT://kafka:29092,LISTENER_EXT://kafka:9092
+      KAFKA_CFG_ADVERTISED_LISTENERS: LISTENER_INT://kafka:29092,LISTENER_EXT://localhost:9092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_INT:PLAINTEXT,LISTENER_EXT:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_INT
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
     networks:
       private: {}
 
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: {{ @('zookeeper.image') }}:{{ @('zookeeper.version') }}
     environment:
-      - SERVICE_NAME=zookeeper
-      - CONTAINER_NAME=zk-node-1
-      - ZOOKEEPER_SERVER_IDS=zk-node-1:1
-      - ZOOKEEPER_INSTANCES=zk-node-1
-      - ZOOKEEPER_ZK_NODE_1_HOST=zookeeper
-      - ZOOKEEPER_ZK_NODE_1_CLIENT_PORT=2181
-      - ZOOKEEPER_ZK_NODE_1_PEER_PORT=2888
-      - ZOOKEEPER_ZK_NODE_1_LEADER_ELECTION_PORT=3888
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_SERVERS: zk-node-1:2888:3888::1
     ports:
       - 2181
     networks:

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -32,7 +32,11 @@ attributes.default:
     root_pass: DV6RdNY3QcFsBk7V
 
   kafka:
+    image: bitnami/kafka
     host: "kafka:29092"
+    version: latest
+  zookeeper:
+    image: bitnami/zookeeper
     version: latest
 
   docker:


### PR DESCRIPTION
This switch means we now use a better maintained image for Kafka and Zookeeper, with future native arm64 versions too, as already officially discussed in https://github.com/bitnami/charts/issues/7305#issuecomment-945380961.

Closes #171.