### PR TITLE
Add option to copy additional arbitrary files to production image

### DIFF
--- a/docker/image/app/include/Dockerfile.prod.twig
+++ b/docker/image/app/include/Dockerfile.prod.twig
@@ -11,6 +11,9 @@ COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 {% endif %}
 
 COPY --chown=0:0 --from=base /go/bin/{{ @('app.binary') }} /
+{% for from, to in path_split(@('app.copy_files')) %}
+COPY --chown=0:0 --from=base {{ from }} {{ to }}
+{% endfor %}
 
 {% for binaryPath in @('app.additional_binaries') %}
 {% set sanitizedName = sanitize_additional_binary_path(binaryPath) %}

--- a/docs/harness-attributes.md
+++ b/docs/harness-attributes.md
@@ -101,6 +101,7 @@ These attributes control how the app container is built or how it behaves after 
       mount_volume: false
       additional_binaries: []
       packages: []
+      copy_files: []
 
 #### `binary`
 
@@ -167,6 +168,15 @@ See [the guide](/docs/how-to-guides/add-additional-binaries.md) for more on how 
 #### `packages`
 
 This array attribute allows you to define an arbitrary number of `apt` packages to be installed when the Docker image is being built. Please note that these packages are only installed on the development image, and not the production image.
+
+#### `copy_files`
+
+An array attribute that lets you specify additional file paths that should be copied onto the final production image. These files should be built on the base development image first, as they will be copied from that layer in the production docker build. The format for each entry is `from_path:to_path`, where `from_path` is the path on the base image layer. For example:
+
+```yaml
+copy_files:
+  - "/go/bin/grpc_health_probe:/"
+```
 
 [overriding harness templates]: overriding-files.md
 [`gofmt`]: https://pkg.go.dev/cmd/gofmt

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -18,6 +18,7 @@ attributes.default:
     mount_volume: false
     additional_binaries: []
     packages: []
+    copy_files: []
 
   domain: my127.site
   hostname: = @('namespace') ~ '.' ~ @('domain')

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -231,3 +231,16 @@ function('sanitize_additional_binary_path', [path]): |
       trigger_error(sprintf("Your additional_binary path (%s) contains a leading slash, please remove it.", $path), E_USER_ERROR);
   }
   = str_replace("/", "-", $path);
+
+function('path_split', [paths]): |
+  #!php
+  $splitPaths = [];
+  array_walk($paths, function($path) use (&$splitPaths) {
+      $parts = explode(":", $path);
+      if (count($parts) != 2) {
+          return;
+      }
+      $splitPaths[$parts[0]] = $parts[1];
+  });
+
+  = $splitPaths;


### PR DESCRIPTION
This closes #168 in a generic way and opens up opportunities for additional tooling to be copied onto the production image in future. The build or download of the tool will need to happen in the base docker image, and can be achieved using the `module.before|after.steps` attributes for executing scripts.