### PR TITLE
Bump docker-compose.yml version to 3.7

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -3,7 +3,7 @@
 {% if @('host.os') == 'darwin' and @('docker-sync') == 'yes' %}
 {% set dockersync = true %}
 {% endif %}
-version: '3'
+version: '3.7'
 services:
 {% include blocks ~ 'application.yml.twig' %}
 {% for service in @('app.services') %}


### PR DESCRIPTION
This brings it in-line with the PHP based harnesses and fixes an issue with our `docker-compose.yml` on older `docker-compose` versions