### PR TITLE
Use a volume mount by default to run everything in docker

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 This document highlights breaking changes in releases that will require some migration effort in your project. As we move towards a `1.0.0` release these will be restricted to major upgrades only, but currently, whilst the API is still being fleshed out in the `0.x` releases, they may be more frequent.
 
+## `0.13.x` -> `0.14.0`
+
+* The default development workflow has now changed from host to `app` container. Before, the `app` container was still the default way to run your app, but all `ws go ...` commands executed on the host by default. These now run in the `app` container instead.
+* The `ws recompile` command now does an in-place recompile, rather than rebuilding the whole `app` container.
+
 ## `0.12.x` -> `0.13.0`
 
 * The Dockerfiles have been restructured to make multi-platform images easier. You may need to restructure your own template overrides if you use a custom `Dockerfile` or `Dockerfile.prod`, as they have now been moved, see [here](https://github.com/inviqa/harness-go/tree/master/docker/image/app/include).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,7 +7,7 @@ This document highlights breaking changes in releases that will require some mig
 * The default development workflow has now changed from host to `app` container. Before, the `app` container was still the default way to run your app, but all `ws go ...` commands executed on the host by default. These now run in the `app` container instead.
 * The `ws recompile` command now does an in-place recompile, rather than rebuilding the whole `app` container.
 * The `.my127ws/harness/scripts/integration/run.sh` was renamed to `.my127ws/harness/scripts/integration/host-run.sh` to reflect that it runs on the host.
-* The `.my127ws/harness/scripts/integration/host-run-one.sh` file has been removed, as `.my127ws/harness/scripts/integration/host-run.sh` can handle both single and full integration suite test execution.
+* The `.my127ws/harness/scripts/integration/run-one.sh` file has been removed, as `.my127ws/harness/scripts/integration/host-run.sh` can handle both single and full integration suite test execution.
 
 ## `0.12.x` -> `0.13.0`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,8 @@ This document highlights breaking changes in releases that will require some mig
 
 * The default development workflow has now changed from host to `app` container. Before, the `app` container was still the default way to run your app, but all `ws go ...` commands executed on the host by default. These now run in the `app` container instead.
 * The `ws recompile` command now does an in-place recompile, rather than rebuilding the whole `app` container.
+* The `.my127ws/harness/scripts/integration/run.sh` was renamed to `.my127ws/harness/scripts/integration/host-run.sh` to reflect that it runs on the host.
+* The `.my127ws/harness/scripts/integration/host-run-one.sh` file has been removed, as `.my127ws/harness/scripts/integration/host-run.sh` can handle both single and full integration suite test execution.
 
 ## `0.12.x` -> `0.13.0`
 

--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -40,5 +40,7 @@
         @('services.app.environment'),
         @('services.app.environment_secrets'),
      ]), 2, 6) | raw }}
+{% if @('app.build') != "production" %}
     volumes:
       - .:/app
+{% endif %}

--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -40,7 +40,5 @@
         @('services.app.environment'),
         @('services.app.environment_secrets'),
      ]), 2, 6) | raw }}
-{% if @('app.mount_volume') %}
     volumes:
       - .:/app
-{% endif %}

--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -11,18 +11,18 @@ pipeline {
         }
         stage('Test')  {
             parallel {
-                stage('go mod check') { steps { sh 'ws go docker mod check' } }
-                stage('go fmt') { steps { sh 'ws go docker fmt check' } }
-                stage('go test') { steps { sh 'ws go docker test' } }
-                stage('go vet') { steps { sh 'ws go docker vet' } }
-                stage('go gocyclo') { steps { sh 'ws go docker gocyclo' } }
-                stage('go ineffassign') { steps { sh 'ws go docker ineffassign' } }
-                stage('go gosec') { steps { sh 'ws go docker gosec' } }
+                stage('go mod check') { steps { sh 'ws go mod check' } }
+                stage('go fmt') { steps { sh 'ws go fmt check' } }
+                stage('go test') { steps { sh 'ws go test' } }
+                stage('go vet') { steps { sh 'ws go vet' } }
+                stage('go gocyclo') { steps { sh 'ws go gocyclo' } }
+                stage('go ineffassign') { steps { sh 'ws go ineffassign' } }
+                stage('go gosec') { steps { sh 'ws go gosec' } }
                 stage('helm kubeval qa') { steps { sh 'ws helm kubeval qa' } }
             }
         }
         stage('Integration Tests') {
-            steps { sh 'ws go test integration docker' }
+            steps { sh 'ws go test integration' }
         }
         stage('Build for production') {
             steps {

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ This is the documentation for the Go harness.
     * [How to add a database to your app](how-to-guides/add-a-database.md)
     * [How to add benchmarks to your app](how-to-guides/add-benchmarks.md)
     * [How to add Kafka (and Zookeeper)](how-to-guides/add-kafka.md)
+    * [How to add the Kafka Outbox Relay](how-to-guides/add-kafka-outbox-relay.md)
+    * [How to create multi-platform images](how-to-guides/create-multi-platform-images.md)
     * [How to test a production image build locally](how-to-guides/test-production-image-build-locally.md)
     * [How to use private external images](how-to-guides/use-private-external-images.md)
     * [How to write integration tests](how-to-guides/write-integration-tests.md)

--- a/docs/development-and-production.md
+++ b/docs/development-and-production.md
@@ -8,10 +8,12 @@ This works really well when we are developing, as we will want to be able to ins
 
 ## Production
 
-When we create a production image in our CI pipeline we want to produce a lighter weight image. We build this on top of [Docker's scratch image] which has no shell, and an empty files system without any packages. In our [`Dockerfile.prod.twig`] we do two things:
+When we create a production image in our CI pipeline we want to produce a lighter weight image. We build this on top of [Docker's scratch image] which has no shell, and an empty files system without any packages. In our [`Dockerfile.prod.twig`] we:
 
 1. Copy certificates from the development image to the production one  (if `app.bundle_certs` is set to `'yes'`)
-1. Copy the compiled binary from the development image to the production one
+2. Copy timezone info from the development image to the production one  (if `app.bundle_timezone_info` is set to `'yes'`)
+3. Copy the compiled binary from the development image to the production one
+4. Copy any [additional binaries] to the production image, if configured.
 
 The second step is quite key, because when looking at the base [`Dockerfile`] it looks strange to see the `go build` step towards the end of it is different based on the build mode. This is hopefully clear from this description, we do that because the production build step is just a copy of the binary compiled during the development image build.
 
@@ -26,3 +28,4 @@ You can find out how to do this in the [how to guide].
 [`Dockerfile.prod`]: /docker/image/app/include/Dockerfile.prod.twig
 [`Dockerfile`]: /docker/image/app/include/Dockerfile.base.twig
 [how to guide]: /docs/how-to-guides/test-production-image-build-locally.md
+[additional binaries]: /docs/how-to-guides/add-additional-binaries.md

--- a/docs/harness-attributes.md
+++ b/docs/harness-attributes.md
@@ -98,7 +98,6 @@ These attributes control how the app container is built or how it behaves after 
         type: standard
         protocol: = @('app.default_port.protocol')
       bundle_certs: no
-      mount_volume: false
       additional_binaries: []
       packages: []
       copy_files: []
@@ -148,10 +147,6 @@ This allows us to enable the bundling of certificates when the production image 
 #### `bundle_timezone_info`
 
 This allows the bundling of timezone info when the production image is being built. This will not affect your local development, because we do not use the production image locally, however, when CI pipelines prepare the production image (based on [Docker's scratch image](https://hub.docker.com/_/scratch/)), we will need to set this value to `true` if we want to access timezone info. Generally, this is only required if you want to operate across multiple timezones.
-
-#### `mount_volume`
-
-When set to `true`, the `app` container will share a volume with the host operating system. Defaults to `false`, which isolates the `app` container filesystem from the host, meaning the developer will run all standard Go workflow commands on the host machine rather than in the `app` container.
 
 #### `additional_binaries`
 

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -15,7 +15,6 @@ attributes.default:
       protocol: = @('app.default_port.protocol')
     bundle_certs: no # todo: this should be standardised as a boolean, rather than "no"/"yes"
     bundle_timezone_info: false
-    mount_volume: false
     additional_binaries: []
     packages: []
     copy_files: []

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -59,67 +59,67 @@ command('go generate'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go generate
+    .my127ws/harness/scripts/docker/compose-exec.sh go generate
 
 command('go test'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go test ./...
+    .my127ws/harness/scripts/docker/compose-exec.sh go test ./...
 
 command('go vet'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go vet -tags=benchmarks ./...
+    .my127ws/harness/scripts/docker/compose-exec.sh go vet -tags=benchmarks ./...
 
 command('go gocyclo'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app helper gocyclo
+    .my127ws/harness/scripts/docker/compose-exec.sh helper gocyclo
 
 command('go gosec'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app helper gosec
+    .my127ws/harness/scripts/docker/compose-exec.sh helper gosec
 
 command('go ineffassign'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app helper ineffassign
+    .my127ws/harness/scripts/docker/compose-exec.sh helper ineffassign
 
 command('go fmt check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru test -z "$(docker-compose exec app helper fmt:check)"
+    passthru test -z "$(.my127ws/harness/scripts/docker/compose-exec.sh helper fmt:check)"
 
 command('go mod check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app helper modules:check
+    .my127ws/harness/scripts/docker/compose-exec.sh helper modules:check
 
 command('go test coverage'):
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go test -coverprofile=cp.out ./...
+    .my127ws/harness/scripts/docker/compose-exec.sh go test -coverprofile=cp.out ./...
     go tool cover -html=cp.out
 
 command('go test integration host'):
   exec: |
     #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/integration/run.sh
+    source .my127ws/harness/scripts/integration/host-run.sh
 
 command('go test integration host <test-name>'):
   env:
@@ -127,14 +127,14 @@ command('go test integration host <test-name>'):
     TEST_NAME: = input.argument('test-name')
   exec: |
     #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
+    source .my127ws/harness/scripts/integration/host-run.sh "${TEST_NAME}"
 
 command('go test integration'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
+    source .my127ws/harness/scripts/integration/run.sh
 
 command('go test integration <test-name>'):
   env:
@@ -142,28 +142,28 @@ command('go test integration <test-name>'):
     TEST_NAME: = input.argument('test-name')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
+    source .my127ws/harness/scripts/integration/run.sh "${TEST_NAME}"
 
 command('go bench compare'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app .my127ws/harness/scripts/bench/compare.sh
+    .my127ws/harness/scripts/docker/compose-exec.sh .my127ws/harness/scripts/bench/compare.sh
 
 command('go bench report'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app .my127ws/harness/scripts/bench/report.sh
+    .my127ws/harness/scripts/docker/compose-exec.sh .my127ws/harness/scripts/bench/report.sh
 
 command('go bench current'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
+    .my127ws/harness/scripts/docker/compose-exec.sh go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
 
 command('go bench'):
   env:
@@ -177,15 +177,15 @@ command('go fmt'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app @('go.formatter') -w -l .
+    .my127ws/harness/scripts/docker/compose-exec.sh @('go.formatter') -w -l .
 
 command('recompile'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec app go mod download
-    passthru docker-compose exec app go build -o /go/bin/app .
+    .my127ws/harness/scripts/docker/compose-exec.sh go mod download
+    .my127ws/harness/scripts/docker/compose-exec.sh go build -o /go/bin/app .
     passthru docker-compose restart app
 
 command('use prod'):

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -59,61 +59,61 @@ command('go generate'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go generate
+    passthru docker-compose exec app go generate
 
 command('go test'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go test ./...
+    passthru docker-compose exec app go test ./...
 
 command('go vet'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go vet -tags=benchmarks ./...
+    passthru docker-compose exec app go vet -tags=benchmarks ./...
 
 command('go gocyclo'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app helper gocyclo
+    passthru docker-compose exec app helper gocyclo
 
 command('go gosec'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app helper gosec
+    passthru docker-compose exec app helper gosec
 
 command('go ineffassign'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app helper ineffassign
+    passthru docker-compose exec app helper ineffassign
 
 command('go fmt check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru test -z "$(docker-compose exec -T app helper fmt:check)"
+    passthru test -z "$(docker-compose exec app helper fmt:check)"
 
 command('go mod check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app helper modules:check
+    passthru docker-compose exec app helper modules:check
 
 command('go test coverage'):
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go test -coverprofile=cp.out ./...
+    passthru docker-compose exec app go test -coverprofile=cp.out ./...
     go tool cover -html=cp.out
 
 command('go test integration host'):
@@ -134,7 +134,7 @@ command('go test integration'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
+    passthru docker-compose exec -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
 
 command('go test integration <test-name>'):
   env:
@@ -142,28 +142,28 @@ command('go test integration <test-name>'):
     TEST_NAME: = input.argument('test-name')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
+    passthru docker-compose exec app .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
 
 command('go bench compare'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app .my127ws/harness/scripts/bench/compare.sh
+    passthru docker-compose exec app .my127ws/harness/scripts/bench/compare.sh
 
 command('go bench report'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app .my127ws/harness/scripts/bench/report.sh
+    passthru docker-compose exec app .my127ws/harness/scripts/bench/report.sh
 
 command('go bench current'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
+    passthru docker-compose exec app go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
 
 command('go bench'):
   env:
@@ -177,15 +177,15 @@ command('go fmt'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app @('go.formatter') -w -l .
+    passthru docker-compose exec app @('go.formatter') -w -l .
 
 command('recompile'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -T app go mod download
-    passthru docker-compose exec -T app go build -o /go/bin/app .
+    passthru docker-compose exec app go mod download
+    passthru docker-compose exec app go build -o /go/bin/app .
     passthru docker-compose restart app
 
 command('use prod'):

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -175,6 +175,7 @@ command('recompile'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
+    passthru docker-compose exec -T app go mod download
     passthru docker-compose exec -T app go build -o /go/bin/app .
     passthru docker-compose restart app
 

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -54,56 +54,56 @@ command('console'): |
   #!php
   $ws->run('app');
 
-command('go docker generate'):
+command('go generate'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go generate
 
-command('go docker test'):
+command('go test'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go test ./...
 
-command('go docker vet'):
+command('go vet'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go vet -tags=benchmarks ./...
 
-command('go docker gocyclo'):
+command('go gocyclo'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper gocyclo
 
-command('go docker gosec'):
+command('go gosec'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper gosec
 
-command('go docker ineffassign'):
+command('go ineffassign'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app helper ineffassign
 
-command('go docker fmt check'):
+command('go fmt check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru test -z "$(docker-compose exec -T app helper fmt:check)"
 
-command('go docker mod check'):
+command('go mod check'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
@@ -113,14 +113,29 @@ command('go docker mod check'):
 command('go test coverage'):
   exec: |
     #!bash(workspace:/)|@
-    go test -coverprofile=cp.out ./... && go tool cover -html=cp.out
+    passthru docker-compose exec -T app go test -coverprofile=cp.out ./...
+    go tool cover -html=cp.out
 
-command('go test integration docker'):
+command('go test integration'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
+
+# todo: is this host version required?
+command('go test integration host'):
+  exec: |
+    #!bash(workspace:/)|@
+    source .my127ws/harness/scripts/integration/run.sh
+
+command('go test integration host <test-name>'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
+    TEST_NAME: = input.argument('test-name')
+  exec: |
+    #!bash(workspace:/)|@
+    source .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
 
 command('go test integration <test-name>'):
   env:
@@ -128,27 +143,22 @@ command('go test integration <test-name>'):
     TEST_NAME: = input.argument('test-name')
   exec: |
     #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/integration/run-one.sh ${TEST_NAME}
-
-command('go test integration'):
-  exec: |
-    #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/integration/run.sh
+    passthru docker-compose exec -T app .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
 
 command('go bench compare'):
   exec: |
     #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/bench/compare.sh
+    passthru docker-compose exec -T app .my127ws/harness/scripts/bench/compare.sh
 
 command('go bench report'):
   exec: |
     #!bash(workspace:/)|@
-    source .my127ws/harness/scripts/bench/report.sh
+    passthru docker-compose exec -T app .my127ws/harness/scripts/bench/report.sh
 
 command('go bench current'):
   exec: |
     #!bash(workspace:/)|@
-    go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
+    passthru docker-compose exec -T app go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
 
 command('go bench'):
   exec: |
@@ -158,14 +168,15 @@ command('go bench'):
 command('go fmt'):
   exec: |
     #!bash(workspace:/)|@
-    @('go.formatter') -w -l .
+    passthru docker-compose exec -T app @('go.formatter') -w -l .
 
 command('recompile'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru ws harness prepare && docker-compose up -d --build app
+    passthru docker-compose exec -T app go build -o /go/bin/app .
+    passthru docker-compose restart app
 
 command('use prod'):
   env:
@@ -174,7 +185,7 @@ command('use prod'):
     #!bash(workspace:/)|@
     passthru ws harness prepare
     passthru ws build-prod
-    passthru && docker-compose up -d app
+    passthru docker-compose up -d app
 
 # borrowed from https://github.com/inviqa/harness-base-php/blob/1.2.x/src/_base/harness/config/commands.yml#L179
 command('set <attribute> <value>'):

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -116,14 +116,6 @@ command('go test coverage'):
     passthru docker-compose exec -T app go test -coverprofile=cp.out ./...
     go tool cover -html=cp.out
 
-command('go test integration'):
-  env:
-    COMPOSE_PROJECT_NAME: = @('namespace')
-  exec: |
-    #!bash(workspace:/)|@
-    passthru docker-compose exec -T -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
-
-# todo: is this host version required?
 command('go test integration host'):
   exec: |
     #!bash(workspace:/)|@
@@ -137,6 +129,13 @@ command('go test integration host <test-name>'):
     #!bash(workspace:/)|@
     source .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
 
+command('go test integration'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)|@
+    passthru docker-compose exec -T -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/
+
 command('go test integration <test-name>'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
@@ -146,26 +145,36 @@ command('go test integration <test-name>'):
     passthru docker-compose exec -T app .my127ws/harness/scripts/integration/run-one.sh "${TEST_NAME}"
 
 command('go bench compare'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app .my127ws/harness/scripts/bench/compare.sh
 
 command('go bench report'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app .my127ws/harness/scripts/bench/report.sh
 
 command('go bench current'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app go test -count=5 -bench=. -benchmem --tags=benchmarks ./benchmarks/
 
 command('go bench'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     ws go bench current
 
 command('go fmt'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose exec -T app @('go.formatter') -w -l .

--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -17,7 +17,6 @@ confd('harness:/'):
   - { src: harness/scripts/docker/build-prod.sh }
   - { src: harness/scripts/docker/publish.sh }
   - { src: harness/scripts/integration/host-run.sh }
-  - { src: harness/scripts/integration/host-run-one.sh }
   - { src: helm/app/Chart.yaml }
   - { src: helm/app/values.yaml }
   - { src: helm/app/values-production.yaml }

--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -16,8 +16,8 @@ confd('harness:/'):
   - { src: harness/scripts/init.sh }
   - { src: harness/scripts/docker/build-prod.sh }
   - { src: harness/scripts/docker/publish.sh }
-  - { src: harness/scripts/integration/run.sh }
-  - { src: harness/scripts/integration/run-one.sh }
+  - { src: harness/scripts/integration/host-run.sh }
+  - { src: harness/scripts/integration/host-run-one.sh }
   - { src: helm/app/Chart.yaml }
   - { src: helm/app/values.yaml }
   - { src: helm/app/values-production.yaml }

--- a/harness/scripts/docker/compose-exec.sh
+++ b/harness/scripts/docker/compose-exec.sh
@@ -4,8 +4,7 @@ function compose_exec()
 {
   local noTtyFlag=""
 
-  tty -s;
-  if [ "0" != "$?" ]; then
+  if [ ! -t 1 ]; then
     noTtyFlag="-T"
   fi
 

--- a/harness/scripts/docker/compose-exec.sh
+++ b/harness/scripts/docker/compose-exec.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+function compose_exec()
+{
+  local noTtyFlag=""
+
+  tty -s;
+  if [ "0" != "$?" ]; then
+    noTtyFlag="-T"
+  fi
+
+  docker-compose exec $noTtyFlag app "$@"
+}
+
+compose_exec "$@"

--- a/harness/scripts/integration/host-run.sh.twig
+++ b/harness/scripts/integration/host-run.sh.twig
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+integration_run() {
+  local testFlag=""
+
+  if [ "" != "$1" ]; then
+    testFlag="-run $1"
+  fi
+
+  env -- {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/ $testFlag
+}
+
+integration_run "$1"

--- a/harness/scripts/integration/run-one.sh.twig
+++ b/harness/scripts/integration/run-one.sh.twig
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-integration_run_one() {
-    env -- {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=debug go test -count=1 -v --tags=integration ./integration/ -run "$1"
-}
-
-integration_run_one "$1"

--- a/harness/scripts/integration/run.sh
+++ b/harness/scripts/integration/run.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-integration_run() {
+function integration_run() {
   local noTtyFlag=""
   local testFlag=""
 
@@ -8,11 +8,11 @@ integration_run() {
     testFlag="-run $1"
   fi
 
-  tty -s;
-  if [ "0" != "$?" ]; then
+  if [ ! -t 1 ]; then
     noTtyFlag="-T"
   fi
 
+  echo "docker-compose exec $noTtyFlag -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/ $testFlag"
   docker-compose exec $noTtyFlag -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/ $testFlag
 }
 

--- a/harness/scripts/integration/run.sh
+++ b/harness/scripts/integration/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+integration_run() {
+  local noTtyFlag=""
+  local testFlag=""
+
+  if [ "" != "$1" ]; then
+    testFlag="-run $1"
+  fi
+
+  tty -s;
+  if [ "0" != "$?" ]; then
+    noTtyFlag="-T"
+  fi
+
+  docker-compose exec $noTtyFlag -e GO_TEST_MODE=docker -e LOG_LEVEL=error app go test -count=1 -v --tags=integration ./integration/ $testFlag
+}
+
+integration_run "$1"

--- a/harness/scripts/integration/run.sh.twig
+++ b/harness/scripts/integration/run.sh.twig
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-integration_run() {
-    env -- {% for name, value in @('services.app.environment') -%}{{ escapeshellarg(name) }}={{ escapeshellarg(value) }} {% endfor %} LOG_LEVEL=error go test -count=1 -v --tags=integration ./integration/
-}
-
-integration_run


### PR DESCRIPTION
TODO:
- [x] settle on the command API
- [x] update the docs
- [x] test :)
- [x] only set `-T` on `docker-compose exec` commands when needed (pipelines)
- [x] fix the `ws go test integration <test-name>` command
- [x] ensure pipeline integration tests run OK

https://github.com/inviqa/go-sample/pull/16 is a demonstration of this working in pipelines.

This would close #196.

NOTE: I've labelled this as a breaking change, but it shouldn't break any workflows, it should just make them more efficient. The main thing that will change is the `ws recompile` command, which will no longer rebuild the whole app container.