### PR TITLE
Set buildkit env vars for ws recompile

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -163,6 +163,8 @@ command('go fmt'):
 command('recompile'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
+    COMPOSE_DOCKER_CLI_BUILD: "1"
+    DOCKER_BUILDKIT: "1"
   exec: |
     #!bash(workspace:/)|@
     passthru ws harness prepare && docker-compose up -d --build app


### PR DESCRIPTION
Currently, on `docker-compose` < 2, `ws recompile` errors because these env vars are missing.