### PR TITLE
Add horizontal pod autoscaler and pod disruption budgets

### DIFF
--- a/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,44 @@
+{{- range $serviceName, $service := .Values.docker.services -}}
+{{- with $service }}
+{{- $autoscaling := .autoscaling | default (dict) -}}
+{{- if and (not (hasPrefix "." $serviceName)) (hasKey $.Values.service $serviceName | ternary (index $.Values.service $serviceName) .enabled) $autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ print $.Release.Name "-" $serviceName }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+    app.service: {{ print $.Release.Name "-" $serviceName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+spec:
+  {{- with (omit $autoscaling "enabled" "metrics") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+  metrics:
+    {{- with $autoscaling.metrics }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+    {{- with $autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+    {{- end }}
+    {{- with $autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ print $.Release.Name "-" $serviceName }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/app/templates/pod-disruption-budgets.yaml
+++ b/helm/app/templates/pod-disruption-budgets.yaml
@@ -1,0 +1,25 @@
+{{- range $serviceName, $service := .Values.docker.services -}}
+{{- with $service }}
+{{- if and (not (hasPrefix "." $serviceName)) (hasKey $.Values.service $serviceName | ternary (index $.Values.service $serviceName) .enabled) }}
+{{- $autoscaling := .autoscaling | default (dict "minReplicas" 0) -}}
+{{- if or (gt (.replicas | default 1) 1) (and $autoscaling.enabled (gt $autoscaling.minReplicas 1)) }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ print $.Values.resourcePrefix $serviceName }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName}}
+    app.service: {{ print $.Values.resourcePrefix $serviceName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+spec:
+  minAvailable: {{- .minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app.service: {{ print $.Values.resourcePrefix $serviceName }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
autoscaler will be added based on .Values.docker.services.*.autoscaling config,
and pod disruption budgets default to minAvailable 1 only if minimum replicas is greater than 1

needs https://github.com/inviqa/harness-go/pull/205 for app to be able to use this