### PR TITLE
Allow defining replicas from attributes, removing the existing setting by default

### DIFF
--- a/helm/app/templates/application/app/deployment.yaml
+++ b/helm/app/templates/application/app/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/component: app
     app.service: {{ $.Values.resourcePrefix }}app
 spec:
+{{- with (pick . "replicas") }}
+{{- . | toYaml | nindent 2 }}
+{{- end }}
   selector:
     matchLabels:
       app.service: {{ $.Values.resourcePrefix }}app

--- a/helm/app/templates/application/app/deployment.yaml
+++ b/helm/app/templates/application/app/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/component: app
     app.service: {{ $.Values.resourcePrefix }}app
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.service: {{ $.Values.resourcePrefix }}app


### PR DESCRIPTION
If you have something restoring the cluster's state to a known helm chart state (e.g. ArgoCD), it will fight over the replica count
in the manifest versus the dynamic state set by HorizontalPodAutoscaler.