### PR TITLE
Print out what is happening during ws recompile

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -186,7 +186,9 @@ command('recompile'):
     DOCKER_BUILDKIT: "1"
   exec: |
     #!bash(workspace:/)|@
+    echo "go mod download"
     .my127ws/harness/scripts/docker/compose-exec.sh go mod download
+    echo "go build -o /go/bin/app"
     .my127ws/harness/scripts/docker/compose-exec.sh go build -o /go/bin/app .
     passthru docker-compose restart app
 


### PR DESCRIPTION
It helps engineers understand what is happening during the recompile, as recently it came to light that sometimes people thought it was only restarting the app container and not actually doing a recompile. Sample output now looks like:

```
$ ws recompile
go mod download
go build -o /go/bin/app
[/my-project]:
■ > docker-compose restart app
Restarting my-project-app-1 ... done
```