### PR TITLE
Update k8s Ingress to v1 and add optional ingressClassName

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,13 @@ This document highlights breaking changes in releases that will require some mig
 
 ## `0.16.x` -> `0.17.0`
 
+### Kubernetes Ingress v1
+Cloud Kubernetes providers such as Digitial Ocean will be forcing upgrades of Kubernetes to 1.22 in a few months, and will obsolete, amongst other things, Ingress extensions/v1beta1 and networking.k8s.io/v1beta1 apiVersions.
+
+This release includes an upgrade from extensions/v1beta1 to networking.k8s.io/v1 apiVersion of Ingress resources to handle that.
+
+Care is needed to ensure GitOps cluster deploy tools can handle this, which includes ArgoCD needing to be at least version 1.8, due to a bug in applying networking.k8s.io/v1 Ingresses failing.
+
 ### MySQL
 
 We are switching back to Docker Inc's official mysql for arm64 computers, as it now supports arm64 on 8.0-oracle tag. This was also done because Oracle's mysql-server repository changed it's image publishing structure to no longer be multi-platform images.

--- a/helm/app/templates/application/app/ingress.yaml
+++ b/helm/app/templates/application/app/ingress.yaml
@@ -23,7 +23,9 @@ spec:
   - host: {{ .Values.docker.services.app.environment.APP_HOST }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: Prefix
+        backend:
           service:
             name: {{ .Values.resourcePrefix }}app
             port:

--- a/helm/app/templates/application/app/ingress.yaml
+++ b/helm/app/templates/application/app/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     app.service: {{ .Values.resourcePrefix }}app
   name: {{ .Values.resourcePrefix }}app
 spec:
-  {{- with (pick .Values.ingress "ingressClassName") }}
+  {{- with (pick .Values.ingress "ingressClassName" "tls") }}
   {{- . | toYaml | nindent 2 }}
   {{- end }}
   rules:
@@ -28,10 +28,6 @@ spec:
             name: {{ .Values.resourcePrefix }}app
             port:
               number: {{ .Values.default_port.port }}
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- toYaml .Values.ingress.tls | nindent 4 }}
-{{- end }}
 status:
   loadBalancer: {}
 {{ end }}

--- a/helm/app/templates/application/app/ingress.yaml
+++ b/helm/app/templates/application/app/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Values.ingress.type "standard" }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- with .Values.ingress.annotations }}
@@ -16,13 +16,18 @@ metadata:
     app.service: {{ .Values.resourcePrefix }}app
   name: {{ .Values.resourcePrefix }}app
 spec:
+  {{- with (pick .Values.ingress "ingressClassName") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   rules:
   - host: {{ .Values.docker.services.app.environment.APP_HOST }}
     http:
       paths:
       - backend:
-          serviceName: {{ .Values.resourcePrefix }}app
-          servicePort: {{ .Values.default_port.port }}
+          service:
+            name: {{ .Values.resourcePrefix }}app
+            port:
+              number: {{ .Values.default_port.port }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- toYaml .Values.ingress.tls | nindent 4 }}


### PR DESCRIPTION
Needed for k8s 1.22, supported since 1.19, and requires ArgoCD > 1.8