### PR TITLE
Fix wrong platform mysql image on arm64 with new mysql:8.0-oracle image

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,21 @@
 
 This document highlights breaking changes in releases that will require some migration effort in your project. As we move towards a `1.0.0` release these will be restricted to major upgrades only, but currently, whilst the API is still being fleshed out in the `0.x` releases, they may be more frequent.
 
+## `0.16.x` -> `0.17.0`
+
+### MySQL
+
+We are switching back to Docker Inc's official mysql for arm64 computers, as it now supports arm64 on 8.0-oracle tag. This was also done because Oracle's mysql-server repository changed it's image publishing structure to no longer be multi-platform images.
+
+You can switch to any of the previous settings setting:
+
+e.g. to Docker Inc's official mysql 5.7 (with no arm64 support)
+```
+attribute('services.mysql.version'): '5.7'
+# since it's a multi-platform image of only one platform
+attribute('services.mysql.platform'): linux/amd64 
+```
+
 ## `0.14.x` -> `0.15.0`
 
 * app.services in workspace.yml is deprecated and replaced with services.*.enabled. It will still continue to function until obsoleted

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -10,9 +10,9 @@ attributes:
         memory: 100Mi
     mysql:
       enabled: "= 'mysql' in @('app.services')" 
-      # prefer native platform mysql image. _/mysql doesn't have arm64 images
-      image: "= (host_architecture() == 'amd64' ? 'mysql:' : 'mysql/mysql-server:') ~ @('services.mysql.version')"
-      version: "8.0"
+      image: "= 'mysql:' ~ @('services.mysql.version')"
+      # arm64 support is currently in a different tag
+      version: "= host_architecture() == 'amd64' ? '8.0' : '8.0-oracle'"
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_USER: = @('database.user')


### PR DESCRIPTION
mysql/mysql-server:8.0 stopped being a multi-platform image sometime after it was implemented here