### PR TITLE
Deprecate bundle_timezone_info attribute due to time/tzdata solution

### DIFF
--- a/docs/harness-attributes.md
+++ b/docs/harness-attributes.md
@@ -144,7 +144,9 @@ These settings are related to changing the ingress used for your application. Va
 
 This allows us to enable the bundling of certificates when the production image is being built. This will not affect your local development, because we do not use the production image locally, however, when CI pipelines prepare the production image (based on [Docker's scratch image](https://hub.docker.com/_/scratch/)), we will need to set this value to `'yes'` if we communicate with any services that use TLS. Without these, the application will not be able to complete a TLS handshake with those services. See [development and production](development-and-production.md) for more info.
 
-#### `bundle_timezone_info`
+#### `bundle_timezone_info` (deprecated)
+
+Deprecated, since go 1.15 you can `import _ "time/tzdata"` into the application itself to bundle tzdata in the binary.
 
 This allows the bundling of timezone info when the production image is being built. This will not affect your local development, because we do not use the production image locally, however, when CI pipelines prepare the production image (based on [Docker's scratch image](https://hub.docker.com/_/scratch/)), we will need to set this value to `true` if we want to access timezone info. Generally, this is only required if you want to operate across multiple timezones.
 

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -15,7 +15,7 @@ attributes.default:
       type: standard
       protocol: = @('app.default_port.protocol')
     bundle_certs: no # todo: this should be standardised as a boolean, rather than "no"/"yes"
-    bundle_timezone_info: false
+    bundle_timezone_info: false # deprecated, import time/tzdata instead
     additional_binaries: []
     packages: []
     copy_files: []


### PR DESCRIPTION
You can `import _ "time/tzdata"` since go 1.15, to get tzdata bundled into the binary.

We may keep the attribute around as it could still be useful for multiple binaries.